### PR TITLE
fix: update alias and topics

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -22,7 +22,7 @@
       "type-output-directory",
       "visibility"
     ],
-    "alias": ["force:cmdt:generate", "cmdt:generate"]
+    "alias": ["force:cmdt:generate"]
   },
   {
     "command": "generate:cmdt:object",

--- a/package.json
+++ b/package.json
@@ -112,12 +112,7 @@
         "description": "Commands to generate a project, create a function, and more.",
         "subtopics": {
           "cmdt": {
-            "description": "Commands to generate custom metadata types and their records.",
-            "subtopics": {
-              "record": {
-                "description": "Generate custom metadata type records."
-              }
-            }
+            "description": "Commands to generate custom metadata types and their records."
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "/csvtojson",
     "/lib",
     "/messages",
-    "/oclif.manifest.json"
+    "/oclif.manifest.json",
+    "/schemas"
   ],
   "homepage": "https://github.com/salesforcecli/plugin-custom-metadata",
   "keywords": [
@@ -106,11 +107,12 @@
       "@salesforce/plugin-command-reference"
     ],
     "topics": {
-      "force": {
+      "generate": {
         "external": true,
+        "description": "Commands to generate a project, create a function, and more.",
         "subtopics": {
           "cmdt": {
-            "description": "Generate custom metadata types and their records.",
+            "description": "Commands to generate custom metadata types and their records.",
             "subtopics": {
               "record": {
                 "description": "Generate custom metadata type records."

--- a/src/commands/generate/cmdt/fromorg.ts
+++ b/src/commands/generate/cmdt/fromorg.ts
@@ -38,7 +38,7 @@ export default class Generate extends SfCommand<CmdtGenerateResponse> {
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static readonly requiresProject = true;
-  public static readonly aliases = ['force:cmdt:generate', 'cmdt:generate'];
+  public static readonly aliases = ['force:cmdt:generate'];
 
   public static readonly flags = {
     'target-org': requiredOrgFlagWithDeprecations,


### PR DESCRIPTION
fix this error (the alias collided with the new topic)

$ sf generate cmdt --help
Generate a custom metadata type and all its records from a Salesforce object.

USAGE
 $ sf generate cmdt fromorg -o <value> -n <value> -s (etc....)
