### PR TITLE
Edit messages to take out extraneous backslashes 

### DIFF
--- a/messages/field.md
+++ b/messages/field.md
@@ -6,21 +6,21 @@ Generate a field for a custom metadata type based on the provided field type.
 
 Similar to a custom object, a custom metadata type has a list of custom fields that represent aspects of the metadata.
 
-This command creates a metadata file that describes the new custom metadata type field. By default, the file is created in a "fields" directory in the current directory. Use the --output-directory to generate the file in the directory that contains the custom metadata type metdata files, such as "force-app/main/default/objects/MyCmdt\_\_mdt" for the custom metadata type called MyCmdt.
+This command creates a metadata file that describes the new custom metadata type field. By default, the file is created in a "fields" directory in the current directory. Use the --output-directory to generate the file in the directory that contains the custom metadata type metdata files, such as "force-app/main/default/objects/MyCmdt__mdt" for the custom metadata type called MyCmdt.
 
 # examples
 
-- Generate a metadata file for a custom checkbox field and add the file to the MyCmdt\_\_mdt/fields directory:
+- Generate a metadata file for a custom checkbox field and add the file to the MyCmdt__mdt/fields directory:
 
-  <%= config.bin %> <%= command.id %> --name MyCheckboxField --type Checkbox --output-directory force-app/main/default/objects/MyCmdt\_\_mdt
+  <%= config.bin %> <%= command.id %> --name MyCheckboxField --type Checkbox --output-directory force-app/main/default/objects/MyCmdt__mdt
 
 - Generate a metadata file for a custom picklist field and add a few values:
 
-  <%= config.bin %> <%= command.id %> --name MyPicklistField --type Picklist --picklist-values A --picklist-values B --picklist-values C --output-directory force-app/main/default/objects/MyCmdt\_\_mdt
+  <%= config.bin %> <%= command.id %> --name MyPicklistField --type Picklist --picklist-values A --picklist-values B --picklist-values C --output-directory force-app/main/default/objects/MyCmdt__mdt
 
 - Generate a metadata file for a custom number field and specify 2 decimal places:
 
-  <%= config.bin %> <%= command.id %> --name MyNumberField --type Number --decimal-places 2 --output-directory force-app/main/default/objects/MyCmdt\_\_mdt
+  <%= config.bin %> <%= command.id %> --name MyNumberField --type Number --decimal-places 2 --output-directory force-app/main/default/objects/MyCmdt__mdt
 
 # flags.name.summary
 

--- a/messages/fromorg.md
+++ b/messages/fromorg.md
@@ -6,33 +6,33 @@ Generate a custom metadata type and all its records from a Salesforce object.
 
 Use this command to migrate existing custom objects or custom settings in an org to custom metadata types. If a field of the Salesforce object is of an unsupported type, the field type is automatically converted to text. Run "<%= config.bin %> cmdt field create --help" to see the list of supported cmdt field types, listed in the --type flag summary. Use the --ignore-unsupported to ignore these fields.
 
-This command creates the metadata files that describe the new custom metadata type and its fields in the "force-app/main/default/objects/TypeName\_\_mdt" directory by default, where "TypeName" is the value of the required --dev-name flag. Use --type-output-directory to create them in a different directory.
+This command creates the metadata files that describe the new custom metadata type and its fields in the "force-app/main/default/objects/TypeName__mdt" directory by default, where "TypeName" is the value of the required --dev-name flag. Use --type-output-directory to create them in a different directory.
 
 # examples
 
-- Generate a custom metadata type from a custom object called MySourceObject\_\_c in your default org:
+- Generate a custom metadata type from a custom object called MySourceObject__c in your default org:
 
-  <%= config.bin %> <%= command.id %> --dev-name MyCMDT --sobject MySourceObject\_\_c
+  <%= config.bin %> <%= command.id %> --dev-name MyCMDT --sobject MySourceObject__c
 
 - Generate a custom metadata type from a custom object in an org with alias my-scratch-org; ignore unsupported field types instead of converting them to text:
 
-  <%= config.bin %> <%= command.id %> --dev-name MyCMDT --sobject MySourceObject\_\_c --ignore-unsupported --target-org my-scratch-org
+  <%= config.bin %> <%= command.id %> --dev-name MyCMDT --sobject MySourceObject__c --ignore-unsupported --target-org my-scratch-org
 
 - Generate a protected custom metadata type from a custom object:
 
-  <%= config.bin %> <%= command.id %> --dev-name MyCMDT --sobject MySourceObject\_\_c --visibility Protected
+  <%= config.bin %> <%= command.id %> --dev-name MyCMDT --sobject MySourceObject__c --visibility Protected
 
 - Generate a protected custom metadata type from a custom setting with a specific singular and plural label:
 
-  <%= config.bin %> <%= command.id %> --dev-name MyCMDT --label "My CMDT" --plural-label "My CMDTs" --sobject MySourceSetting\_\_c --visibility Protected
+  <%= config.bin %> <%= command.id %> --dev-name MyCMDT --label "My CMDT" --plural-label "My CMDTs" --sobject MySourceSetting__c --visibility Protected
 
 - Generate a custom metadata type and put the resulting metadata files in the specified directory:
 
-  <%= config.bin %> <%= command.id %> --dev-name MyCMDT --sobject MySourceObject\_\_c --type-output-directory path/to/my/cmdt/directory
+  <%= config.bin %> <%= command.id %> --dev-name MyCMDT --sobject MySourceObject__c --type-output-directory path/to/my/cmdt/directory
 
 - Generate a custom metadata type and put the resulting record metadata file(s) in the specified directory:
 
-  <%= config.bin %> <%= command.id %> --dev-name MyCMDT --sobject MySourceObject\_\_c --records-output-dir path/to/my/cmdt/record/directory
+  <%= config.bin %> <%= command.id %> --dev-name MyCMDT --sobject MySourceObject__c --records-output-dir path/to/my/cmdt/record/directory
 
 # flags.visibility.summary
 

--- a/messages/object.md
+++ b/messages/object.md
@@ -4,7 +4,7 @@ Generate a new custom metadata type in the current project.
 
 # description
 
-This command creates a metadata file that describes the new custom metadata type. By default, the file is created in the MyCustomType\_\_mdt directory in the current directory, where MyCustomType is the value of the required --type-name flag. Use the --output-directory to generate the file in a package directory with other custom metadata types, such as "force-app/main/default/objects".
+This command creates a metadata file that describes the new custom metadata type. By default, the file is created in the MyCustomType__mdt directory in the current directory, where MyCustomType is the value of the required --type-name flag. Use the --output-directory to generate the file in a package directory with other custom metadata types, such as "force-app/main/default/objects".
 
 # examples
 

--- a/messages/record.md
+++ b/messages/record.md
@@ -10,15 +10,15 @@ The custom metadata type must already exist in your project. You must specify a 
 
 - Create a record metadata file for custom metadata type 'MyCMT' with specified values for two custom fields:
 
-  <%= config.bin %> <%= command.id %> --type-name MyCMT\_\_mdt --record-name MyRecord My_Custom_Field_1=Foo My_Custom_Field_2=Bar
+  <%= config.bin %> <%= command.id %> --type-name MyCMT__mdt --record-name MyRecord My_Custom_Field_1=Foo My_Custom_Field_2=Bar
 
 - Create a protected record metadata file for custom metadata type 'MyCMT' with a specific label and values specified for two custom fields:
 
-  <%= config.bin %> <%= command.id %> --type-name MyCMT\_\_mdt --record-name MyRecord --label "My Record" --protected true My_Custom_Field_1=Foo My_Custom_Field_2=Bar
+  <%= config.bin %> <%= command.id %> --type-name MyCMT__mdt --record-name MyRecord --label "My Record" --protected true My_Custom_Field_1=Foo My_Custom_Field_2=Bar
 
 # flags.type-name.summary
 
-API name of the custom metadata type to create a record for; must end in "\_\_mdt".
+API name of the custom metadata type to create a record for; must end in "__mdt".
 
 # flags.record-name.summary
 

--- a/messages/records.md
+++ b/messages/records.md
@@ -34,7 +34,7 @@ API name of the custom metadata type to create a record for.
 
 # flags.type-name.description
 
-The '\_\_mdt' suffix is appended to the end of the name if it's omitted.
+The '__mdt' suffix is appended to the end of the name if it's omitted.
 
 # flags.name-column.summary
 


### PR DESCRIPTION
My dev env has a bad setting somewhere in which I sometimes automatically introduce backslashes in MD files (Object__c becomes Object\_\_c).  Gotta figure it out!  But in the meantime, here's a manual fix.

@W-12378151@