### PR TITLE
Correctly transform record name

### DIFF
--- a/src/commands/cmdt/generate/records.ts
+++ b/src/commands/cmdt/generate/records.ts
@@ -75,9 +75,14 @@ export default class Insert extends SfCommand<CreateConfigs> {
       columns: (header: string[]) => columnValidation(metadataTypeFields, header, flags['type-name']),
     }) as Record[];
 
+    // Transforms on the recordname are to match the behavior of adding a new Custom Metadata Type record in the UI
     const recordConfigs: CreateConfig[] = parsedRecords.map((record) => ({
       typename: flags['type-name'],
-      recordname: (record[flags['name-column']] as string).replace(' ', '_'),
+      recordname: (record[flags['name-column']] as string)
+        .replace(/[^a-zA-Z0-9]/g, '_') // replace all non-alphanumeric characters with _
+        .replace(/^(\d)/, 'X$1') // prepend an X if the first character is a number
+        .replace(/_{2,}/g, '_') // replace multiple underscores with single underscore
+        .replace(/_$/, ''), // remove trailing underscore (if any)
       label: record[flags['name-column']] as string,
       inputdir: flags['input-directory'],
       outputdir: flags['output-directory'],


### PR DESCRIPTION
[@W-13482203@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-13482203)

Updates the recordname generation to match the UI

You can test with the steps here https://github.com/forcedotcom/cli/issues/2158
Or just changes values in the added NUT to confirm it is working correctly

From the UI:
<img width="796" alt="Screenshot 2023-05-24 at 5 31 14 PM" src="https://github.com/salesforcecli/plugin-custom-metadata/assets/1715111/c9fb7996-57ac-4cc5-b12b-5f7832edc9aa">
