### PR TITLE
fix: handle undefined in cmdt record creation

### DIFF
--- a/src/shared/helpers/createUtil.ts
+++ b/src/shared/helpers/createUtil.ts
@@ -129,23 +129,18 @@ export const getFieldNames = (fileData: CustomField[], nameField: string): strin
  * @param  fileData Array of objects that contain field data
  * @return {string} String representation of XML
  */
-const buildCustomFieldXml = (
+export const buildCustomFieldXml = (
   fileData: CustomField[] = [],
   cliParams: Record<string, string> = {},
   ignoreFields = false
-): string => {
-  let ret = '';
-  for (const fieldName of Object.keys(cliParams)) {
-    const type = getFieldPrimitiveType(fileData, fieldName);
-    const dataType = getFieldDataType(fileData, fieldName);
-    // Added functionality to handle the ignore fields scenario.
-    if (canConvert(dataType) || !ignoreFields) {
-      ret += getFieldTemplate(fieldName, cliParams[fieldName], type);
-    }
-  }
-
-  return ret;
-};
+): string =>
+  Object.entries(cliParams)
+    .filter(
+      ([fieldName, value]) =>
+        value !== undefined && (canConvert(getFieldDataType(fileData, fieldName)) || !ignoreFields)
+    )
+    .map(([fieldName, value]) => getFieldTemplate(fieldName, value, getFieldPrimitiveType(fileData, fieldName)))
+    .join('');
 
 /**
  * Get the number type based on the scale.

--- a/src/shared/templates/templates.ts
+++ b/src/shared/templates/templates.ts
@@ -55,7 +55,7 @@ export const createFieldXML = (data: CustomField, defaultToString: boolean): str
   returnValue += getLengthTag(data);
   returnValue += getVisibleLines(data);
 
-  // preventing standard objects that have fields that are being convered from passing in data
+  // preventing standard objects that have fields that are being converted from passing in data
   // that is no longer relevant
   // e.g. multiselectpicklist are being converted to long text area and long text area's do not support valuesets
   if (canConvert(data.type)) {

--- a/test/unit/createUtil.test.ts
+++ b/test/unit/createUtil.test.ts
@@ -4,9 +4,11 @@
  * Licensed under the BSD 3-Clause license.
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+/* eslint-disable camelcase */
 
 import { expect } from 'chai';
-import { appendDirectorySuffix } from '../../src/shared/helpers/createUtil.js';
+import { CustomField } from 'jsforce/lib/api/metadata.js';
+import { appendDirectorySuffix, buildCustomFieldXml } from '../../src/shared/helpers/createUtil.js';
 
 describe('CreateUtil', () => {
   describe('appendDirectorySuffix', () => {
@@ -16,6 +18,75 @@ describe('CreateUtil', () => {
 
       expect(output1 === 'foo__mdt').to.be.true;
       expect(output2 === 'foobar__mdt').to.be.true;
+    });
+  });
+
+  describe('buildCustomFieldXml', () => {
+    const fields = [
+      {
+        fullName: 'Test__c',
+        label: 'Test',
+        type: 'Text',
+      },
+      {
+        fullName: 'Test2__c',
+        label: 'Test2',
+        type: 'Checkbox',
+      },
+    ] as CustomField[];
+
+    it('2 fields that are convertible become records', () => {
+      const xml = buildCustomFieldXml(fields, { Test__c: 'foo', Test2__c: 'true' });
+      expect(xml).to.equal(`
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:string">foo</value>
+    </values>
+    <values>
+        <field>Test2__c</field>
+        <value xsi:type="xsd:boolean">true</value>
+    </values>`);
+    });
+    it('undefined values do not become records', () => {
+      const xml = buildCustomFieldXml(fields, { Test__c: 'foo' });
+
+      expect(xml).to.equal(`
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:string">foo</value>
+    </values>`);
+    });
+    describe('non-convertible fields', () => {
+      const fieldsWithLookup = [
+        ...fields,
+        {
+          fullName: 'Test3__c',
+          label: 'Test3',
+          type: 'Lookup',
+        } as CustomField,
+      ];
+
+      it('2 fields that are convertible with a non-convertible one when ignoreFields=true', () => {
+        const xml = buildCustomFieldXml(fieldsWithLookup, { Test__c: 'foo', Test3__c: 'badValue' }, true);
+        // that 2nd one is omitted because it has no value
+        expect(xml).to.equal(`
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:string">foo</value>
+    </values>`);
+      });
+      it('2 fields that are convertible with a non-convertible one and ignoreFields=false', () => {
+        const xml = buildCustomFieldXml(fieldsWithLookup, { Test__c: 'foo', Test3__c: 'badValue' }, false);
+        expect(xml).to.equal(`
+    <values>
+        <field>Test__c</field>
+        <value xsi:type="xsd:string">foo</value>
+    </values>
+    <values>
+        <field>Test3__c</field>
+        <value xsi:type="xsd:string">badValue</value>
+    </values>`);
+      });
     });
   });
 });


### PR DESCRIPTION
it was possible to get `undefined` in the customField xml.  

This change skips fields where the user provided no value.

[@W-13055835@](https://gus.lightning.force.com/a07EE00001PiQ2xYAF)
https://github.com/forcedotcom/cli/issues/2074
https://github.com/forcedotcom/cli/issues/1714

closes Known Issue https://issues.salesforce.com/issue/a028c00000j5kO8AAI/custom-metadata-forcecmdtrecordinsert-command-is-creating-undefined-types-for-null-values-in-csv-file